### PR TITLE
Use the standard `TouchEvent` API instead of the safari-specific `GestureEvent` API.

### DIFF
--- a/javascripts/fractalSounds.js
+++ b/javascripts/fractalSounds.js
@@ -478,9 +478,9 @@ function setupEventHandlers() {
 
   // Define these on the canvas so that we don't override events for the controls.
   canvas.addEventListener("touchstart", function (e) {
-    e.preventDefault();
-
     if (e.targetTouches.length === 2 && !gesturing) {
+      e.preventDefault();
+
       const touchA = e.targetTouches[0];
       const touchB = e.targetTouches[1];
 


### PR DESCRIPTION
`GestureEvent` is only supported in Safari, so I migrated this over to use `TouchEvent` instead.
It's a bit lower-level, so I had to do some more stuff manually, but it's not too bad.

I also improved the pinch-to-zoom behaviour slightly by making it preserve roughly where each finger is on the fractal, instead of just dragging by the midpoint of the two fingers.